### PR TITLE
Change to prioritize displayName over name + Fix XSS issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ class InstantiateReactComponentOptimizer {
             component.mountComponent = wrap(
               component.mountComponent,
               function (mount) {
-                const cmpName = (curEl.type.name || curEl.type.displayName);
+                const cmpName = (curEl.type.displayName || curEl.type.name);
                 const generatedKey = self.config.components[cmpName].cacheKeyGen(curEl.props);
                 if (generatedKey === null) {
                   return mount.apply(component, [].slice.call(arguments, 1));

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const Module = require("module");
 const require_ = Module.prototype.require;
 const InstantiateReactComponent = require("react/lib/instantiateReactComponent");
+const EscapeTextContentForBrowser = require("react/lib/escapeTextContentForBrowser");
 
 const get = require("lodash/get");
 const set = require("lodash/set");
@@ -86,6 +87,7 @@ class InstantiateReactComponentOptimizer {
       templateAttrs.forEach((attrKey) => {
         const _attrKey = attrKey.replace(".", "__");
         set(curEl.props, attrKey, templateAttrValues[_attrKey]);
+        templateAttrValues[_attrKey] = EscapeTextContentForBrowser(templateAttrValues[_attrKey]);
       });
       return compiled(templateAttrValues);
     };


### PR DESCRIPTION
Right now if you use webpack or other to compress the code, an issue emerges. While the shouldComponentBeCached short circuits after checking self.componentsToCache.indexOf(curEl.type.displayName) > EMPTY_ID, it then assumes the component name (and therefore the key with which to look up the cacheKeyGen function) in a different order: const cmpName = (curEl.type.displayName || curEl.type.name);.

If compressing your code, often the curEl.type.name will be equal to something non-sensical like t. This results in components being detected as cacheable, and then trying to find a cacheKeyGen function for a component entry with the key t resulting in an undefined error.

+

Added fix for [#5](https://github.com/walmartlabs/electrode-react-ssr-optimization/issues/5)